### PR TITLE
add spoiler option to roll

### DIFF
--- a/commands/roll.js
+++ b/commands/roll.js
@@ -1,6 +1,7 @@
 const { SlashCommandBuilder } = require('@discordjs/builders');
 const Discord = require("discord.js");
 const { DNDBRoll } = require("../dice");
+const { WhisperType } = require("../constants");
 
 module.exports = {
 	data: new SlashCommandBuilder()
@@ -21,13 +22,17 @@ module.exports = {
                 .setDescription("The description for the roll"))
         .addBooleanOption(option => 
             option.setName('whisper')
-                .setDescription("Whisper the result to self")),
+                .setDescription("Whisper the result to self"))
+        .addBooleanOption(option => 
+            option.setName('spoilers')
+                .setDescription("Set whether or not roll details should be hidden behind spoiler tags")),
 	async execute(interaction, bot) {
         const formula = interaction.options.getString("formula");
         const whisper = interaction.options.getBoolean("whisper");
         const title = interaction.options.getString("title");
         const name = interaction.options.getString("name");
         const description = interaction.options.getString("description");
+        const spoilers = interaction.options.getBoolean("spoilers") ?? true;
         const roll = new DNDBRoll(formula);
         await roll.roll();
         const rollData = roll.toJSON();
@@ -52,7 +57,10 @@ module.exports = {
             rollEmbed.setColor('#990000')
         else
             rollEmbed.setColor('#999999')
-        rollEmbed.addField(bot.rollToDetails(rollData), bot.rollToSpoiler(rollData));
+        // set up options
+        const options = [];
+        if (!spoilers) options.push("nospoilers");
+        rollEmbed.addField(bot.rollToDetails(rollData), bot.rollToSpoiler(rollData, WhisperType.NO, options));
 		await interaction.reply({
             embeds: [rollEmbed],
             ephemeral: whisper === true


### PR DESCRIPTION
closes https://github.com/kakaroto/Beyond20/issues/1007

- defaults to true
- if set to false, will not hide formula + details behind spoiler

-----

- [x] I agree to license my contribution under GPL-3.0 or my contribution is from another project with a license compatible with GPL-3.0