### PR TITLE
Add role-based access for /secret command

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,3 +18,7 @@ BOT_TOKEN=<bot token>
 
 SECRET_KEY_CHANNEL_PASSWORD=<secret encryption key>
 ```
+
+## Role-Based Access
+
+By default, only the Discord server owner can use the `/secret` command to generate secret keys for channels. However, server owners can create a role named **"Beyond20 Admin"** and assign it to trusted users to grant them access to the `/secret` command as well.

--- a/bot.js
+++ b/bot.js
@@ -13,7 +13,7 @@ const turndownService = new TurndownService()
 
 class Bot {
     constructor() {
-        this.client = new Discord.Client({ intents: [Discord.Intents.FLAGS.GUILDS] });
+        this.client = new Discord.Client({ intents: [Discord.Intents.FLAGS.GUILDS, Discord.Intents.FLAGS.GUILD_MEMBERS] });
         this.client.commands = new Discord.Collection();
         const commandFiles = fs.readdirSync(commandsDir).filter(file => file.endsWith('.js'));
         

--- a/commands/secret.js
+++ b/commands/secret.js
@@ -21,9 +21,14 @@ module.exports = {
             option.setName('spoilers')
                 .setDescription("Set whether or not roll details should be hidden behind spoiler tags")),
 	async execute(interaction) {
+        if (!interaction.inGuild()) {
+            return interaction.reply({content: 'This command can only be used in a server.', ephemeral: true});
+        }
+
         const owner = interaction.guild.ownerId;
         const isOwner = interaction.user.id === owner;
-        const hasAdminRole = interaction.member.roles.cache.some(role => role.name === 'Beyond20 Admin');
+        const member = await interaction.member.fetch();
+        const hasAdminRole = member.roles.cache.some(role => role.name === 'Beyond20 Admin');
         
         if (!isOwner && !hasAdminRole) {
             return interaction.reply({content: 'Only the server owner or users with the "Beyond20 Admin" role can use this command.', ephemeral: true});

--- a/commands/secret.js
+++ b/commands/secret.js
@@ -22,8 +22,11 @@ module.exports = {
                 .setDescription("Set whether or not roll details should be hidden behind spoiler tags")),
 	async execute(interaction) {
         const owner = interaction.guild.ownerId;
-        if (interaction.user.id !== owner) {
-            return interaction.reply({content: 'Only the server owner can use this command.', ephemeral: true});
+        const isOwner = interaction.user.id === owner;
+        const hasAdminRole = interaction.member.roles.cache.some(role => role.name === 'Beyond20 Admin');
+        
+        if (!isOwner && !hasAdminRole) {
+            return interaction.reply({content: 'Only the server owner or users with the "Beyond20 Admin" role can use this command.', ephemeral: true});
         }
 
         let destination = interaction.channel;


### PR DESCRIPTION
- Allow users with 'Beyond20 Admin' role to use /secret command
- Server owners retain full access (no breaking changes)
- Added GUILD_MEMBERS intent to bot.js for role checking
- Updated README with documentation for new role-based access feature

This change allows server owners to delegate /secret command access to trusted users by creating a 'Beyond20 Admin' role on their server, reducing the need for server owner intervention when managing channels.